### PR TITLE
test(course): implementa testes unitários e de integração

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,18 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/br/com/maestria/maestria_course_service/MaestriaCourseServiceApplicationTests.java
+++ b/src/test/java/br/com/maestria/maestria_course_service/MaestriaCourseServiceApplicationTests.java
@@ -2,8 +2,10 @@ package br.com.maestria.maestria_course_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MaestriaCourseServiceApplicationTests {
 
 	@Test

--- a/src/test/java/br/com/maestria/maestria_course_service/controller/CourseControllerTest.java
+++ b/src/test/java/br/com/maestria/maestria_course_service/controller/CourseControllerTest.java
@@ -1,0 +1,270 @@
+package br.com.maestria.maestria_course_service.controller;
+
+
+import br.com.maestria.maestria_course_service.dto.request.CreateCourseRequest;
+import br.com.maestria.maestria_course_service.dto.request.UpdateCourseRequest;
+import br.com.maestria.maestria_course_service.entity.Course;
+import br.com.maestria.maestria_course_service.repository.CourseRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @AfterEach
+    void tearDown() {
+        courseRepository.deleteAll();
+    }
+
+    private JwtGrantedAuthoritiesConverter authoritiesConverter() {
+        JwtGrantedAuthoritiesConverter converter = new JwtGrantedAuthoritiesConverter();
+        converter.setAuthorityPrefix("ROLE_");
+        converter.setAuthoritiesClaimName("roles");
+        return converter;
+    }
+    @Nested
+    @DisplayName("POST /api/v1/courses - Criação de Cursos")
+    class CreateCourseTests {
+
+        @Test
+        @DisplayName("Deve retornar 201 Created quando o usuário for ADMIN")
+        void createCourse_WhenUserIsAdmin_ShouldReturn201Created() throws Exception {
+            CreateCourseRequest request = new CreateCourseRequest();
+            request.setTitle("Curso de Teste de Integração");
+            request.setDescription("Descrição do teste");
+
+            mockMvc.perform(post("/api/v1/courses")
+                            .with(jwt().jwt(j -> j
+                                                    .subject(UUID.randomUUID().toString())
+                                                    .claim("tenantId", UUID.randomUUID().toString())
+                                                    .claim("roles", Collections.singletonList("ADMIN"))
+                                            )
+                                            .authorities(authoritiesConverter())
+                            )
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").isNotEmpty())
+                    .andExpect(jsonPath("$.title").value("Curso de Teste de Integração"));
+        }
+
+        @Test
+        @WithMockUser(roles = "ALUNO")
+        @DisplayName("Deve retornar 403 Forbidden quando o usuário for ALUNO")
+        void createCourse_WhenUserIsAluno_ShouldReturn403Forbidden() throws Exception {
+            CreateCourseRequest request = new CreateCourseRequest();
+            request.setTitle("Tentativa de Criação por Aluno");
+
+            mockMvc.perform(post("/api/v1/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/courses - Listagem de Cursos")
+    class GetAllCoursesTests {
+
+        @Test
+        @DisplayName("Deve retornar 200 OK e a lista de cursos")
+        void getAllCourses_ShouldReturn200OkAndCourseList() throws Exception {
+            Course course = Course.builder()
+                    .title("Curso Público")
+                    .description("Descrição pública")
+                    .instructorId(UUID.randomUUID())
+                    .tenantId(UUID.randomUUID())
+                    .build();
+            courseRepository.save(course);
+
+            mockMvc.perform(get("/api/v1/courses"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].title").value("Curso Público"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/courses - Cenários Adicionais de Criação")
+    class CreateCourseExtraScenariosTests {
+
+        @Test
+        @DisplayName("Deve retornar 201 Created quando o usuário for INSTRUTOR")
+        void createCourse_WhenUserIsInstructor_ShouldReturn201Created() throws Exception {
+            CreateCourseRequest request = new CreateCourseRequest();
+            request.setTitle("Curso Criado por Instrutor");
+            request.setDescription("Descrição do instrutor");
+
+            mockMvc.perform(post("/api/v1/courses")
+                            .with(jwt().jwt(j -> j
+                                                    .subject(UUID.randomUUID().toString())
+                                                    .claim("tenantId", UUID.randomUUID().toString())
+                                                    .claim("roles", Collections.singletonList("INSTRUTOR"))
+                                            )
+                                            .authorities(authoritiesConverter())
+                            )
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.title").value("Curso Criado por Instrutor"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/courses/{id} - Busca por ID")
+    class GetCourseByIdTests {
+
+        @Test
+        @DisplayName("Deve retornar 200 OK e o curso quando o ID existe")
+        void getCourseById_WhenCourseExists_ShouldReturn200Ok() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("Curso por ID").description("Desc").instructorId(UUID.randomUUID()).tenantId(UUID.randomUUID()).build());
+
+            mockMvc.perform(get("/api/v1/courses/{id}", course.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(course.getId().toString()))
+                    .andExpect(jsonPath("$.title").value("Curso por ID"));
+        }
+
+        @Test
+        @DisplayName("Deve retornar 404 Not Found quando o ID não existe")
+        void getCourseById_WhenCourseDoesNotExist_ShouldReturn404NotFound() throws Exception {
+            mockMvc.perform(get("/api/v1/courses/{id}", UUID.randomUUID()))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/courses/{id} - Atualização de Cursos")
+    class UpdateCourseTests {
+
+        private final UUID ownerInstructorId = UUID.randomUUID();
+        private final UUID otherInstructorId = UUID.randomUUID();
+        private final UUID tenantId = UUID.randomUUID();
+
+        @Test
+        @DisplayName("Deve retornar 200 OK quando o INSTRUTOR proprietário atualiza o curso")
+        void updateCourse_WhenOwnerInstructor_ShouldReturn200Ok() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("Original").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+            UpdateCourseRequest request = new UpdateCourseRequest();
+            request.setTitle("Atualizado pelo Dono");
+            request.setDescription("Nova desc");
+
+            mockMvc.perform(put("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(ownerInstructorId.toString()).claim("roles", Collections.singletonList("INSTRUTOR")))
+                                    .authorities(authoritiesConverter())
+                            )
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("Atualizado pelo Dono"));
+        }
+
+        @Test
+        @DisplayName("Deve retornar 200 OK quando o ADMIN atualiza um curso que não lhe pertence")
+        void updateCourse_WhenAdmin_ShouldReturn200Ok() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("Original").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+            UpdateCourseRequest request = new UpdateCourseRequest();
+            request.setTitle("Atualizado pelo Admin");
+            request.setDescription("Nova desc");
+
+            mockMvc.perform(put("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(UUID.randomUUID().toString()).claim("roles", Collections.singletonList("ADMIN")))
+                                    .authorities(authoritiesConverter())
+                            )
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("Atualizado pelo Admin"));
+        }
+
+        @Test
+        @DisplayName("Deve retornar 403 Forbidden quando um INSTRUTOR tenta atualizar um curso que não lhe pertence")
+        void updateCourse_WhenNotOwnerInstructor_ShouldReturn403Forbidden() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("Original").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+            UpdateCourseRequest request = new UpdateCourseRequest();
+            request.setTitle("Tentativa de fraude");
+
+            mockMvc.perform(put("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(otherInstructorId.toString()).claim("roles", Collections.singletonList("INSTRUTOR")))
+                                    .authorities(authoritiesConverter())
+                            )
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/courses/{id} - Exclusão de Cursos")
+    class DeleteCourseTests {
+
+        private final UUID ownerInstructorId = UUID.randomUUID();
+        private final UUID otherInstructorId = UUID.randomUUID();
+        private final UUID tenantId = UUID.randomUUID();
+
+        @Test
+        @DisplayName("Deve retornar 204 No Content quando o INSTRUTOR proprietário exclui o curso")
+        void deleteCourse_WhenOwnerInstructor_ShouldReturn204NoContent() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("A ser deletado").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+
+            mockMvc.perform(delete("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(ownerInstructorId.toString()).claim("roles", Collections.singletonList("INSTRUTOR")))
+                                    .authorities(authoritiesConverter())
+                            ))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("Deve retornar 204 No Content quando o ADMIN exclui um curso que não lhe pertence")
+        void deleteCourse_WhenAdmin_ShouldReturn204NoContent() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("A ser deletado").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+
+            mockMvc.perform(delete("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(UUID.randomUUID().toString()).claim("roles", Collections.singletonList("ADMIN")))
+                                    .authorities(authoritiesConverter())
+                            ))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("Deve retornar 403 Forbidden quando um INSTRUTOR tenta excluir um curso que não lhe pertence")
+        void deleteCourse_WhenNotOwnerInstructor_ShouldReturn403Forbidden() throws Exception {
+            Course course = courseRepository.save(Course.builder().title("A ser deletado").description("Desc").instructorId(ownerInstructorId).tenantId(tenantId).build());
+
+            mockMvc.perform(delete("/api/v1/courses/{id}", course.getId())
+                            .with(jwt().jwt(j -> j.subject(otherInstructorId.toString()).claim("roles", Collections.singletonList("INSTRUTOR")))
+                                    .authorities(authoritiesConverter())
+                            ))
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/src/test/java/br/com/maestria/maestria_course_service/service/CourseServiceImplTest.java
+++ b/src/test/java/br/com/maestria/maestria_course_service/service/CourseServiceImplTest.java
@@ -1,0 +1,182 @@
+package br.com.maestria.maestria_course_service.service;
+
+import br.com.maestria.maestria_course_service.dto.request.CreateCourseRequest;
+import br.com.maestria.maestria_course_service.dto.request.UpdateCourseRequest;
+import br.com.maestria.maestria_course_service.entity.Course;
+import br.com.maestria.maestria_course_service.exception.ResourceNotFoundException;
+import br.com.maestria.maestria_course_service.repository.CourseRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.OngoingStubbing;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CourseServiceImplTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @InjectMocks
+    private CourseServiceImpl courseService;
+
+    private Jwt mockJwt;
+    private UUID instructorId;
+    private UUID tenantId;
+    private UUID courseId;
+
+    @BeforeEach
+    void setUp() {
+        instructorId = UUID.randomUUID();
+        tenantId = UUID.randomUUID();
+        courseId = UUID.randomUUID();
+        mockJwt = Jwt.withTokenValue("token")
+                .header("alg", "HS256")
+                .subject(instructorId.toString())
+                .claim("tenantId", tenantId.toString())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Testes para criação de cursos")
+    class CreateCourseTests {
+        @Test
+        @DisplayName("Deve salvar e retornar o curso quando os dados são válidos")
+        void createCourse_ShouldSaveAndReturnCourse() {
+            CreateCourseRequest request = new CreateCourseRequest();
+            request.setTitle("Novo Curso de Java");
+            request.setDescription("Descrição do curso de Java");
+
+            when(courseRepository.save(any(Course.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Course result = courseService.createCourse(request, mockJwt);
+
+            assertNotNull(result);
+            assertEquals(request.getTitle(), result.getTitle());
+            assertEquals(instructorId, result.getInstructorId());
+            assertEquals(tenantId, result.getTenantId());
+            verify(courseRepository, times(1)).save(any(Course.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Testes para busca de cursos")
+    class FindCourseTests {
+        @Test
+        @DisplayName("Deve retornar um Optional com o curso quando o ID existe")
+        void findById_WhenCourseExists_ShouldReturnOptionalOfCourse() {
+            Course course = new Course();
+            course.setId(courseId);
+            OngoingStubbing<Optional<Course>> optionalOngoingStubbing = when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+
+            Optional<Course> result = courseService.findById(courseId);
+
+            assertTrue(result.isPresent());
+            assertEquals(courseId, result.get().getId());
+            verify(courseRepository, times(1)).findById(courseId);
+        }
+
+        @Test
+        @DisplayName("Deve retornar um Optional vazio quando o ID não existe")
+        void findById_WhenCourseDoesNotExist_ShouldReturnEmptyOptional() {
+            when(courseRepository.findById(courseId)).thenReturn(Optional.empty());
+
+            Optional<Course> result = courseService.findById(courseId);
+
+            assertFalse(result.isPresent());
+            verify(courseRepository, times(1)).findById(courseId);
+        }
+
+        @Test
+        @DisplayName("Deve retornar uma lista de cursos quando existem cursos")
+        void findAll_WhenCoursesExist_ShouldReturnCourseList() {
+            List<Course> courses = Arrays.asList(new Course(), new Course());
+            when(courseRepository.findAll()).thenReturn(courses);
+
+            List<Course> result = courseService.findAll();
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            verify(courseRepository, times(1)).findAll();
+        }
+
+        @Test
+        @DisplayName("Deve retornar uma lista vazia quando não existem cursos")
+        void findAll_WhenNoCoursesExist_ShouldReturnEmptyList() {
+            when(courseRepository.findAll()).thenReturn(Collections.emptyList());
+
+            List<Course> result = courseService.findAll();
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+            verify(courseRepository, times(1)).findAll();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Testes para atualização de cursos")
+    class UpdateCourseTests {
+        @Test
+        @DisplayName("Deve atualizar e retornar o curso quando o ID existe")
+        void updateCourse_WhenCourseExists_ShouldUpdateAndReturnCourse() {
+            UpdateCourseRequest request = new UpdateCourseRequest();
+            request.setTitle("Curso Atualizado");
+            request.setDescription("Nova descrição");
+
+            Course existingCourse = Course.builder().id(courseId).title("Título Antigo").description("Descrição Antiga").build();
+            when(courseRepository.findById(courseId)).thenReturn(Optional.of(existingCourse));
+            when(courseRepository.save(any(Course.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Course updatedCourse = courseService.updateCourse(courseId, request, mockJwt);
+
+            assertNotNull(updatedCourse);
+            assertEquals(request.getTitle(), updatedCourse.getTitle());
+            assertEquals(request.getDescription(), updatedCourse.getDescription());
+            verify(courseRepository, times(1)).findById(courseId);
+            verify(courseRepository, times(1)).save(existingCourse);
+        }
+
+        @Test
+        @DisplayName("Deve lançar ResourceNotFoundException ao tentar atualizar um curso que não existe")
+        void updateCourse_WhenCourseDoesNotExist_ShouldThrowResourceNotFoundException() {
+            UpdateCourseRequest request = new UpdateCourseRequest();
+            request.setTitle("Curso Inexistente");
+            when(courseRepository.findById(courseId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> {
+                courseService.updateCourse(courseId, request, mockJwt);
+            });
+
+            verify(courseRepository, times(1)).findById(courseId);
+            verify(courseRepository, never()).save(any(Course.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Testes para exclusão de cursos")
+    class DeleteCourseTests {
+
+        @Test
+        @DisplayName("Deve chamar o método deleteById do repositório ao deletar um curso")
+        void deleteCourse_WhenCourseExists_ShouldCallDeleteById() {
+            courseService.deleteCourse(courseId, mockJwt);
+            verify(courseRepository, times(1)).deleteById(courseId);
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:tc:postgresql:15-alpine:///maestria_courses_test
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          secret-key: "ChaveSecretaParaTestesNaoUseEmProducao1234567890"
+
+logging:
+  level:
+    org.springframework: WARN
+    org.hibernate: WARN
+    br.com.maestria: INFO


### PR DESCRIPTION
- Adiciona suíte de testes unitários para CourseServiceImpl, cobrindo todos os métodos públicos com cenários positivos e negativos.
- Implementa testes de integração para CourseController, validando todos os endpoints, incluindo a lógica de autorização por roles (ADMIN, INSTRUTOR) e propriedade do curso.
- Configura o perfil 'test' com um application-test.yml para isolar o ambiente de teste e usar um banco de dados em memória.